### PR TITLE
Add example code

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -116,3 +116,11 @@ Applies all of the following filters, in order:
 * smartypants
 * caps
 * initial_quotes
+
+Examples
+========
+
+Apply all `django-typogrify` filters to template output:
+
+    {% load typogrify_tags %}
+    {{ blog_post.contents|typogrify }}


### PR DESCRIPTION
It's not immediately clear that you need to use `{% load typogrify_tags %}` to use the typogrify filters. I've added a quick example in the README.
