### PR TITLE
Refactor logic out of the django tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 VERSION = '1.3'
 
@@ -9,11 +9,11 @@ setup(
     author='Chris Drackett',
     author_email='chris@tiltshiftstudio.com',
     url='http://github.com/chrisdrackett/django-typogrify',
-    packages = [
+    packages=[
         "typogrify",
         "typogrify.templatetags",
     ],
-    install_requires = [
+    install_requires=[
         'smartypants>=1.6'
     ],
     classifiers=[

--- a/typogrify/templatetags/typogrify_tags.py
+++ b/typogrify/templatetags/typogrify_tags.py
@@ -1,16 +1,13 @@
-import re
 import calendar
 from datetime import date, timedelta
-import smartypants as _smartypants
 
 from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.html import conditional_escape
 from django.utils.translation import ungettext, ugettext
-from django.utils.encoding import force_unicode
 
-import typogrify.titlecase as _titlecase
+import typogrify.filters as _filters
 
 register = template.Library()
 
@@ -32,256 +29,14 @@ def smart_filter(fn):
     return wrapper
 
 
-@smart_filter
-def amp(text, autoescape=None):
-    """Wraps apersands in HTML with ``<span class="amp">`` so they can be
-    styled with CSS. Apersands are also normalized to ``&amp;``. Requires
-    ampersands to have whitespace or an ``&nbsp;`` on both sides.
-
-    >>> amp('One & two')
-    u'One <span class="amp">&amp;</span> two'
-    >>> amp('One &amp; two')
-    u'One <span class="amp">&amp;</span> two'
-    >>> amp('One &#38; two')
-    u'One <span class="amp">&amp;</span> two'
-
-    >>> amp('One&nbsp;&amp;&nbsp;two')
-    u'One&nbsp;<span class="amp">&amp;</span>&nbsp;two'
-
-    It won't mess up & that are already wrapped, in entities or URLs
-
-    >>> amp('One <span class="amp">&amp;</span> two')
-    u'One <span class="amp">&amp;</span> two'
-    >>> amp('&ldquo;this&rdquo; & <a href="/?that&amp;test">that</a>')
-    u'&ldquo;this&rdquo; <span class="amp">&amp;</span> <a href="/?that&amp;test">that</a>'
-
-    It should ignore standalone amps that are in attributes
-    >>> amp('<link href="xyz.html" title="One & Two">xyz</link>')
-    u'<link href="xyz.html" title="One & Two">xyz</link>'
-    """
-
-    # tag_pattern from http://haacked.com/archive/2004/10/25/usingregularexpressionstomatchhtml.aspx
-    # it kinda sucks but it fixes the standalone amps in attributes bug
-    tag_pattern = '</?\w+((\s+\w+(\s*=\s*(?:".*?"|\'.*?\'|[^\'">\s]+))?)+\s*|\s*)/?>'
-    amp_finder = re.compile(r"(\s|&nbsp;)(&|&amp;|&\#38;)(\s|&nbsp;)")
-    intra_tag_finder = re.compile(r'(?P<prefix>(%s)?)(?P<text>([^<]*))(?P<suffix>(%s)?)' % (tag_pattern, tag_pattern))
-
-    def _amp_process(groups):
-        prefix = groups.group('prefix') or ''
-        text = amp_finder.sub(r"""\1<span class="amp">&amp;</span>\3""", groups.group('text'))
-        suffix = groups.group('suffix') or ''
-        return prefix + text + suffix
-    return intra_tag_finder.sub(_amp_process, text)
-
-
-@smart_filter
-def caps(text):
-    """Wraps multiple capital letters in ``<span class="caps">``
-    so they can be styled with CSS.
-
-    >>> caps("A message from KU")
-    u'A message from <span class="caps">KU</span>'
-
-    Uses the smartypants tokenizer to not screw with HTML or with tags it shouldn't.
-
-    >>> caps("<PRE>CAPS</pre> more CAPS")
-    u'<PRE>CAPS</pre> more <span class="caps">CAPS</span>'
-
-    >>> caps("A message from 2KU2 with digits")
-    u'A message from <span class="caps">2KU2</span> with digits'
-
-    >>> caps("Dotted caps followed by spaces should never include them in the wrap D.O.T.   like so.")
-    u'Dotted caps followed by spaces should never include them in the wrap <span class="caps">D.O.T.</span>  like so.'
-
-    All caps with with apostrophes in them shouldn't break. Only handles dump apostrophes though.
-    >>> caps("JIMMY'S")
-    u'<span class="caps">JIMMY\\'S</span>'
-
-    >>> caps("<i>D.O.T.</i>HE34T<b>RFID</b>")
-    u'<i><span class="caps">D.O.T.</span></i><span class="caps">HE34T</span><b><span class="caps">RFID</span></b>'
-    """
-
-    tokens = _smartypants._tokenize(text)
-    result = []
-    in_skipped_tag = False
-
-    cap_finder = re.compile(r"""(
-                            (\b[A-Z\d]*        # Group 2: Any amount of caps and digits
-                            [A-Z]\d*[A-Z]      # A cap string must at least include two caps (but they can have digits between them)
-                            [A-Z\d']*\b)       # Any amount of caps and digits or dumb apostsrophes
-                            | (\b[A-Z]+\.\s?   # OR: Group 3: Some caps, followed by a '.' and an optional space
-                            (?:[A-Z]+\.\s?)+)  # Followed by the same thing at least once more
-                            (?:\s|\b|$))
-                            """, re.VERBOSE)
-
-    def _cap_wrapper(matchobj):
-        """This is necessary to keep dotted cap strings to pick up extra spaces"""
-        if matchobj.group(2):
-            return """<span class="caps">%s</span>""" % matchobj.group(2)
-        else:
-            if matchobj.group(3)[-1] == " ":
-                caps = matchobj.group(3)[:-1]
-                tail = ' '
-            else:
-                caps = matchobj.group(3)
-                tail = ''
-            return """<span class="caps">%s</span>%s""" % (caps, tail)
-
-    tags_to_skip_regex = re.compile("<(/)?(?:pre|code|kbd|script|math)[^>]*>", re.IGNORECASE)
-
-    for token in tokens:
-        if token[0] == "tag":
-            # Don't mess with tags.
-            result.append(token[1])
-            close_match = tags_to_skip_regex.match(token[1])
-            if close_match and close_match.group(1) is None:
-                in_skipped_tag = True
-            else:
-                in_skipped_tag = False
-        else:
-            if in_skipped_tag:
-                result.append(token[1])
-            else:
-                result.append(cap_finder.sub(_cap_wrapper, token[1]))
-    return "".join(result)
-
-
-@smart_filter
-def number_suffix(text):
-    """Wraps date suffix in <span class="ord">
-    so they can be styled with CSS.
-
-    >>> number_suffix("10th")
-    u'10<span class="rod">th</span>'
-
-    Uses the smartypants tokenizer to not screw with HTML or with tags it shouldn't.
-
-    """
-
-    suffix_finder = re.compile(r'(?P<number>[\d]+)(?P<ord>st|nd|rd|th)')
-
-    def _suffix_process(groups):
-        number = groups.group('number')
-        suffix = groups.group('ord')
-
-        return "%s<span class='ord'>%s</span>" % (number, suffix)
-    return suffix_finder.sub(_suffix_process, text)
-
-
-@smart_filter
-def initial_quotes(text):
-    """Wraps initial quotes in ``class="dquo"`` for double quotes or
-    ``class="quo"`` for single quotes. Works in these block tags ``(h1-h6, p, li, dt, dd)``
-    and also accounts for potential opening inline elements ``a, em, strong, span, b, i``
-
-    >>> initial_quotes('"With primes"')
-    u'<span class="dquo">"</span>With primes"'
-    >>> initial_quotes("'With single primes'")
-    u'<span class="quo">\\'</span>With single primes\\''
-
-    >>> initial_quotes('<a href="#">"With primes and a link"</a>')
-    u'<a href="#"><span class="dquo">"</span>With primes and a link"</a>'
-
-    >>> initial_quotes('&#8220;With smartypanted quotes&#8221;')
-    u'<span class="dquo">&#8220;</span>With smartypanted quotes&#8221;'
-    """
-
-    quote_finder = re.compile(r"""((<(p|h[1-6]|li|dt|dd)[^>]*>|^)              # start with an opening p, h1-6, li, dd, dt or the start of the string
-                                  \s*                                          # optional white space!
-                                  (<(a|em|span|strong|i|b)[^>]*>\s*)*)         # optional opening inline tags, with more optional white space for each.
-                                  (("|&ldquo;|&\#8220;)|('|&lsquo;|&\#8216;))  # Find me a quote! (only need to find the left quotes and the primes)
-                                                                               # double quotes are in group 7, singles in group 8
-                                  """, re.VERBOSE)
-
-    def _quote_wrapper(matchobj):
-        if matchobj.group(7):
-            classname = "dquo"
-            quote = matchobj.group(7)
-        else:
-            classname = "quo"
-            quote = matchobj.group(8)
-        return """%s<span class="%s">%s</span>""" % (matchobj.group(1), classname, quote)
-    output = quote_finder.sub(_quote_wrapper, text)
-    return output
-
-
-@smart_filter
-def smartypants(text):
-    """Applies smarty pants to curl quotes.
-
-    >>> smartypants('The "Green" man')
-    u'The &#8220;Green&#8221; man'
-    """
-
-    return _smartypants.smartypants(text)
-
-
-@smart_filter
-def titlecase(text):
-    """Support for titlecase.py's titlecasing
-
-    >>> titlecase("this V that")
-    u'This v That'
-
-    >>> titlecase("this is just an example.com")
-    u'This Is Just an example.com'
-    """
-
-    return _titlecase.titlecase(text)
-
-
-@smart_filter
-def widont(text):
-    """Replaces the space between the last two words in a string with ``&nbsp;``
-    Works in these block tags ``(h1-h6, p, li, dd, dt)`` and also accounts for
-    potential closing inline elements ``a, em, strong, span, b, i``
-
-    >>> widont('A very simple test')
-    u'A very simple&nbsp;test'
-
-    Single word items shouldn't be changed
-    >>> widont('Test')
-    u'Test'
-    >>> widont(' Test')
-    u' Test'
-    >>> widont('<ul><li>Test</p></li><ul>')
-    u'<ul><li>Test</p></li><ul>'
-    >>> widont('<ul><li> Test</p></li><ul>')
-    u'<ul><li> Test</p></li><ul>'
-
-    >>> widont('<p>In a couple of paragraphs</p><p>paragraph two</p>')
-    u'<p>In a couple of&nbsp;paragraphs</p><p>paragraph&nbsp;two</p>'
-
-    >>> widont('<h1><a href="#">In a link inside a heading</i> </a></h1>')
-    u'<h1><a href="#">In a link inside a&nbsp;heading</i> </a></h1>'
-
-    >>> widont('<h1><a href="#">In a link</a> followed by other text</h1>')
-    u'<h1><a href="#">In a link</a> followed by other&nbsp;text</h1>'
-
-    Empty HTMLs shouldn't error
-    >>> widont('<h1><a href="#"></a></h1>')
-    u'<h1><a href="#"></a></h1>'
-
-    >>> widont('<div>Divs get no love!</div>')
-    u'<div>Divs get no love!</div>'
-
-    >>> widont('<pre>Neither do PREs</pre>')
-    u'<pre>Neither do PREs</pre>'
-
-    >>> widont('<div><p>But divs with paragraphs do!</p></div>')
-    u'<div><p>But divs with paragraphs&nbsp;do!</p></div>'
-    """
-
-    widont_finder = re.compile(r"""((?:</?(?:a|em|span|strong|i|b)[^>]*>)|[^<>\s]) # must be proceeded by an approved inline opening or closing tag or a nontag/nonspace
-                                   \s+                                             # the space to replace
-                                   ([^<>\s]+                                       # must be flollowed by non-tag non-space characters
-                                   \s*                                             # optional white space!
-                                   (</(a|em|span|strong|i|b)>\s*)*                 # optional closing inline tags with optional white space after each
-                                   ((</(p|h[1-6]|li|dt|dd)>)|$))                   # end with a closing p, h1-6, li or the end of the string
-                                   """, re.VERBOSE)
-
-    output = widont_finder.sub(r'\1&nbsp;\2', text)
-    return output
+amp = smart_filter(_filters.amp)
+caps = smart_filter(_filters.caps)
+number_suffix = smart_filter(_filters.number_suffix)
+initial_quotes = smart_filter(_filters.initial_quotes)
+smartypants = smart_filter(_filters.smartypants)
+titlecase = smart_filter(_filters.titlecase)
+widont = smart_filter(_filters.widont)
+typogrify = smart_filter(_filters.typogrify)
 
 
 @register.filter
@@ -434,30 +189,6 @@ def super_fuzzydate(value):
         # TODO add the past
         return fuzzydate(value)
 super_fuzzydate.is_safe = True
-
-
-@smart_filter
-def typogrify(text):
-    """The super typography filter
-
-    Applies the following filters: widont, smartypants, caps, amp, initial_quotes
-
-    >>> typogrify('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>')
-    u'<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class="caps">KU</span> fans act extremely&nbsp;obnoxiously</h2>'
-
-    Each filters properly handles autoescaping.
-    >>> conditional_escape(typogrify('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>'))
-    u'<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class="caps">KU</span> fans act extremely&nbsp;obnoxiously</h2>'
-    """
-    text = force_unicode(text)
-    text = amp(text)
-    text = widont(text)
-    text = smartypants(text)
-    text = caps(text)
-    text = initial_quotes(text)
-    text = number_suffix(text)
-
-    return text
 
 
 def _test():

--- a/typogrify/templatetags/typogrify_tags.py
+++ b/typogrify/templatetags/typogrify_tags.py
@@ -8,11 +8,12 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.html import conditional_escape
 from django.utils.translation import ungettext, ugettext
-from django.utils.encoding import smart_str, force_unicode
+from django.utils.encoding import force_unicode
 
 import typogrify.titlecase as _titlecase
 
 register = template.Library()
+
 
 def smart_filter(fn):
     '''
@@ -29,6 +30,7 @@ def smart_filter(fn):
 
     register.filter(fn.__name__, wrapper)
     return wrapper
+
 
 @smart_filter
 def amp(text, autoescape=None):
@@ -63,6 +65,7 @@ def amp(text, autoescape=None):
     tag_pattern = '</?\w+((\s+\w+(\s*=\s*(?:".*?"|\'.*?\'|[^\'">\s]+))?)+\s*|\s*)/?>'
     amp_finder = re.compile(r"(\s|&nbsp;)(&|&amp;|&\#38;)(\s|&nbsp;)")
     intra_tag_finder = re.compile(r'(?P<prefix>(%s)?)(?P<text>([^<]*))(?P<suffix>(%s)?)' % (tag_pattern, tag_pattern))
+
     def _amp_process(groups):
         prefix = groups.group('prefix') or ''
         text = amp_finder.sub(r"""\1<span class="amp">&amp;</span>\3""", groups.group('text'))
@@ -131,7 +134,7 @@ def caps(text):
             # Don't mess with tags.
             result.append(token[1])
             close_match = tags_to_skip_regex.match(token[1])
-            if close_match and close_match.group(1) == None:
+            if close_match and close_match.group(1) is None:
                 in_skipped_tag = True
             else:
                 in_skipped_tag = False
@@ -141,7 +144,6 @@ def caps(text):
             else:
                 result.append(cap_finder.sub(_cap_wrapper, token[1]))
     return "".join(result)
-
 
 
 @smart_filter
@@ -164,6 +166,7 @@ def number_suffix(text):
 
         return "%s<span class='ord'>%s</span>" % (number, suffix)
     return suffix_finder.sub(_suffix_process, text)
+
 
 @smart_filter
 def initial_quotes(text):
@@ -189,6 +192,7 @@ def initial_quotes(text):
                                   (("|&ldquo;|&\#8220;)|('|&lsquo;|&\#8216;))  # Find me a quote! (only need to find the left quotes and the primes)
                                                                                # double quotes are in group 7, singles in group 8
                                   """, re.VERBOSE)
+
     def _quote_wrapper(matchobj):
         if matchobj.group(7):
             classname = "dquo"
@@ -279,6 +283,7 @@ def widont(text):
     output = widont_finder.sub(r'\1&nbsp;\2', text)
     return output
 
+
 @register.filter
 def fuzzydate(value, cutoff=180):
     """
@@ -320,15 +325,18 @@ def fuzzydate(value, cutoff=180):
     today = date.today()
     delta = value - today
 
-    if delta.days == 0: return u"today"
-    elif delta.days == -1: return u"yesterday"
-    elif delta.days == 1: return u"tomorrow"
+    if delta.days == 0:
+        return u"today"
+    elif delta.days == -1:
+        return u"yesterday"
+    elif delta.days == 1:
+        return u"tomorrow"
 
     chunks = (
         (365.0, lambda n: ungettext('year', 'years', n)),
         (30.0, lambda n: ungettext('month', 'months', n)),
-        (7.0, lambda n : ungettext('week', 'weeks', n)),
-        (1.0, lambda n : ungettext('day', 'days', n)),
+        (7.0, lambda n: ungettext('week', 'weeks', n)),
+        (1.0, lambda n: ungettext('day', 'days', n)),
     )
 
     if abs(delta.days) <= cutoff:
@@ -339,8 +347,10 @@ def fuzzydate(value, cutoff=180):
 
         date_str = ugettext('%(number)d %(type)s') % {'number': count, 'type': name(count)}
 
-        if delta.days > 0: return "in " + date_str
-        else: return date_str + " ago"
+        if delta.days > 0:
+            return "in " + date_str
+        else:
+            return date_str + " ago"
     else:
         if value.year == today.year:
             format = getattr(settings, "CURRENT_YEAR_DATE_FORMAT", "F jS")
@@ -349,6 +359,7 @@ def fuzzydate(value, cutoff=180):
 
         return template.defaultfilters.date(value, format)
 fuzzydate.is_safe = True
+
 
 @register.filter
 def super_fuzzydate(value):
@@ -375,7 +386,7 @@ def super_fuzzydate(value):
 
     # if we're in the future...
     if value > today:
-        end_of_week = today + timedelta(days=7-today.isoweekday())
+        end_of_week = today + timedelta(days=7 - today.isoweekday())
         if value <= end_of_week:
             # return the name of the day (Wednesday)
             return u'this %s' % template.defaultfilters.date(value, "l")
@@ -414,7 +425,7 @@ def super_fuzzydate(value):
             return template.defaultfilters.date(value, "F")
 
         # the last day of next year
-        end_of_next_year = date(today.year+1, 12, 31)
+        end_of_next_year = date(today.year + 1, 12, 31)
         if value <= end_of_next_year:
             return u'next %s' % template.defaultfilters.date(value, "F")
 
@@ -423,6 +434,7 @@ def super_fuzzydate(value):
         # TODO add the past
         return fuzzydate(value)
 super_fuzzydate.is_safe = True
+
 
 @smart_filter
 def typogrify(text):
@@ -447,9 +459,11 @@ def typogrify(text):
 
     return text
 
+
 def _test():
     import doctest
     doctest.testmod()
+
 
 if __name__ == "__main__":
     _test()

--- a/typogrify/tests/__init__.py
+++ b/typogrify/tests/__init__.py
@@ -1,1 +1,1 @@
-from typogrify.tests.fuzzydate import *
+from typogrify.tests.fuzzydate import *  # NOQA

--- a/typogrify/tests/fuzzydate.py
+++ b/typogrify/tests/fuzzydate.py
@@ -5,34 +5,35 @@ from django.conf import settings
 
 from typogrify.templatetags.typogrify_tags import fuzzydate
 
+
 class TestFuzzyDate(TestCase):
     def setUp(self):
         settings.DATE_FORMAT = "F jS, Y"
-    
+
     def test_returns_yesterday(self):
         yesterday = datetime.now() - timedelta(hours=24)
         self.assertEquals(fuzzydate(yesterday), "yesterday")
-        
+
         two_days_ago = datetime.now() - timedelta(hours=48)
         self.assertNotEquals(fuzzydate(two_days_ago), "yesterday")
-    
+
     def test_returns_today(self):
         today = datetime.now()
         self.assertEquals(fuzzydate(today), "today")
-    
+
     def test_returns_tomorrow(self):
         tomorrow = datetime.now() + timedelta(hours=24)
         self.assertEquals(fuzzydate(tomorrow), "tomorrow")
-    
+
     def test_formats_current_year(self):
         now = datetime.now()
         testdate = datetime.strptime("%s/10/10" % now.year, "%Y/%m/%d")
-        
+
         expected = "October 10th"
         self.assertEquals(fuzzydate(testdate, 1), expected)
-    
+
     def test_formats_other_years(self):
         testdate = datetime.strptime("1984/10/10", "%Y/%m/%d")
-        
+
         expected = "October 10th, 1984"
         self.assertEquals(fuzzydate(testdate), expected)

--- a/typogrify/titlecase.py
+++ b/typogrify/titlecase.py
@@ -15,18 +15,19 @@ SMALL_FIRST = re.compile(r'^(%s*)(%s)\b' % (PUNCT, SMALL), re.I)
 SMALL_LAST = re.compile(r'\b(%s)%s?$' % (SMALL, PUNCT), re.I)
 SUBPHRASE = re.compile(r'([:.;?!][ ])(%s)' % SMALL)
 
+
 def titlecase(text):
     """
     Titlecases input text
-    
+
     This filter changes all words to Title Caps, and attempts to be clever
     about *un*capitalizing SMALL words like a/an/the in the input.
-    
+
     The list of "SMALL words" which are not capped comes from
     the New York Times Manual of Style, plus 'vs' and 'v'.
-    
+
     """
-    
+
     words = re.split('\s', text)
     line = []
     for word in words:
@@ -37,22 +38,23 @@ def titlecase(text):
             line.append(word.lower())
             continue
         line.append(CAPFIRST.sub(lambda m: m.group(0).upper(), word))
-    
+
     line = " ".join(line)
-    
+
     line = SMALL_FIRST.sub(lambda m: '%s%s' % (
         m.group(1),
         m.group(2).capitalize()
     ), line)
-    
+
     line = SMALL_LAST.sub(lambda m: m.group(0).capitalize(), line)
-    
+
     line = SUBPHRASE.sub(lambda m: '%s%s' % (
         m.group(1),
         m.group(2).capitalize()
     ), line)
-    
+
     return line
+
 
 class TitlecaseTests(unittest.TestCase):
     """Tests to ensure titlecase follows all of the rules"""
@@ -224,8 +226,8 @@ class TitlecaseTests(unittest.TestCase):
         """Testing: Generalissimo Francisco Franco..."""
 
         text = titlecase(
-            'generalissimo francisco franco: still dead; kieren McCarthy: '\
-                'still a jackass'
+            'generalissimo francisco franco: still dead; kieren McCarthy: '
+            'still a jackass'
         )
         result = 'Generalissimo Francisco Franco: Still Dead; Kieren '\
             'McCarthy: Still a Jackass'
@@ -236,7 +238,7 @@ if __name__ == '__main__':
     if not sys.stdin.isatty():
         for line in sys.stdin:
             print titlecase(line)
-    
+
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TitlecaseTests)
         unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
For this code to be more reusable, logic needs to be outside the tags.

This branch does that for most tags, plus adds a couple of naïve replacements for Django's ``conditional_escape`` and ``force_unicode``

Since I am not very familiar with Django templatetags, if any branch was going to break stuff it's this one ;-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chrisdrackett/django-typogrify/9)
<!-- Reviewable:end -->
